### PR TITLE
Wrapped clickable click handler in document.ready

### DIFF
--- a/mysite/myapp/static/js/clickable.js
+++ b/mysite/myapp/static/js/clickable.js
@@ -1,5 +1,7 @@
 console.log('clickable');
 
+$(document).ready(function() {
+
     $(".clickable").mouseup(function(e){
         console.log('click');
         var clicked = $(this);
@@ -64,3 +66,4 @@ console.log('clickable');
        // $(this).html($(this).html().replace(str, replacement));
 
        });
+});


### PR DESCRIPTION
The click handler is now functional on paragraphs not inside Monocle. Still need to make it work inside Monocle.